### PR TITLE
Chapter 11 - Fix bug in types

### DIFF
--- a/Chapter9/Ex_9_1_6.idr
+++ b/Chapter9/Ex_9_1_6.idr
@@ -31,9 +31,8 @@ nilHasNoLast : Last [] value -> Void
 nilHasNoLast LastOne impossible
 nilHasNoLast (LastCons _) impossible
 
-total no : {xs : List a} -> (notFound : Last xs value -> Void) -> Last (x :: xs) value -> Void
-no {xs = []} notFound LastOne impossible
-no {xs = xs} notFound (LastCons prf) = notFound prf
+total no : (notFound : Last (x :: xs) value -> Void) -> Last (_ :: x :: xs) value -> Void
+no notFound (LastCons prf) = notFound prf
 
 total lastNotEq : (con : (x = value) -> Void) -> Last [x] value -> Void
 lastNotEq con LastOne = con Refl
@@ -46,8 +45,8 @@ isLast [x] value =
   case decEq x value of
     Yes Refl => Yes LastOne
     No con => No (lastNotEq con)
-isLast (x :: xs) value = 
-  case isLast xs value of
+isLast (_ :: x :: xs) value =
+  case isLast (x :: xs) value of
     No notFound => No (no notFound)
     Yes LastOne => Yes (LastCons LastOne)
     Yes (LastCons prf) => Yes (LastCons (LastCons prf)) 


### PR DESCRIPTION
Theorem `no` is incorrect and therefore does not (presently)
typecheck.

Here's the error:

```
- + Errors (1)
 `-- Ex_9_1_6.idr line 35 col 30:
     no notFound LastOne is a valid case
```

We can see that the type of `no` is wrong: When the implementation
of `no` is removed (to make it typecheck), we can construct the following
nonsensical value:

```
doesNotMakeSense : Void
doesNotMakeSense = no nilHasNoLast (LastOne {value = 42})
```

This demonstrates that `no`, were it to typecheck, would make our
system inconsistent.

The solution is to make `no` apply only to non-empty lists.